### PR TITLE
Fixing error handling at inizialisation of socket

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -27,9 +27,9 @@ def start():    #Main Program
         sock.bind(('', listening_port))
         sock.listen(max_connection)
         print("[*] Server started successfully [ %d ]" %(listening_port))
-    except Exception:
+    except Exception as e:
         print("[*] Unable to Initialize Socket")
-        print(Exception)
+        print(e)
         sys.exit(2)
 
     while True:


### PR DESCRIPTION
Hi there,

Currently the Exception class will be printed out when the socket is created faulty
rather than the Exception itself. This PR fixes that.

